### PR TITLE
ui: promote rates ladder section

### DIFF
--- a/src/components/Homepage.astro
+++ b/src/components/Homepage.astro
@@ -552,82 +552,80 @@ const pathname = Astro.url.pathname;
   }
 
   .homepage-rates {
-    background: var(--homepage-warm);
-    color: var(--homepage-ink);
+    align-items: start;
+    background: color-mix(
+      in oklab,
+      var(--homepage-ink) 94%,
+      var(--homepage-warm)
+    );
+    color: var(--homepage-paper);
+    display: grid;
+    gap: var(--spacing-xl);
+    grid-template-columns: minmax(18rem, 0.34fr) minmax(0, 0.66fr);
     padding: var(--spacing-2xl) var(--spacing-s-l);
   }
 
-  .homepage-rates__intro {
+  .rates-ladder__aside {
     display: grid;
     gap: var(--spacing-s);
-    margin-block-end: var(--spacing-xl);
-    max-inline-size: 50rem;
+    position: sticky;
+    top: var(--spacing-l);
   }
 
-  .homepage-rates__intro h2 {
+  .rates-ladder__aside h2 {
     font-size: var(--text-step-3);
     letter-spacing: -0.03em;
     line-height: 1.02;
     margin: 0;
-    max-inline-size: 11ch;
   }
 
-  .homepage-rates__intro p {
+  .rates-ladder__aside p,
+  .rates-ladder p,
+  .rates-ladder span {
     margin: 0;
   }
 
-  .homepage-rate-bands {
-    display: grid;
-    margin-block-start: var(--spacing-xl);
-    margin-inline: calc(var(--spacing-s-l) * -1);
+  .rates-ladder__aside p,
+  .rates-ladder__copy > span {
+    color: var(--color-gray-300);
   }
 
-  .homepage-rate-bands a {
-    background: color-mix(
-      in oklab,
-      var(--homepage-ink) 96%,
-      var(--homepage-warm)
-    );
+  .rates-ladder {
+    display: grid;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .rates-ladder li {
     border-block-start: 1px solid rgb(255 255 255 / 0.18);
-    color: var(--homepage-paper);
-    cursor: pointer;
-    display: grid;
-    gap: var(--spacing-l);
-    grid-template-columns: minmax(12rem, 0.42fr) minmax(18rem, 0.7fr) minmax(
-        18rem,
-        0.88fr
-      );
-    padding: var(--spacing-l) var(--spacing-s-l);
-    text-decoration: none;
-    transition:
-      background 180ms ease,
-      transform 180ms ease;
   }
 
-  .homepage-rate-bands a:hover,
-  .homepage-rate-bands a:focus-visible {
-    background: color-mix(
-      in oklab,
-      var(--homepage-ink) 92%,
-      var(--homepage-warm)
-    );
-  }
-
-  .homepage-rate-bands a:focus-visible {
-    outline: 2px solid var(--homepage-soft);
-    outline-offset: -0.25rem;
-  }
-
-  .homepage-rate-bands a:first-child {
+  .rates-ladder li:first-child {
     border-block-start: 0;
   }
 
-  .homepage-rate-bands a > div {
+  .rates-ladder__item {
+    color: var(--homepage-paper);
+    display: grid;
+    gap: var(--spacing-l);
+    grid-template-columns: minmax(16rem, 0.6fr) minmax(14rem, 0.34fr) minmax(
+        7rem,
+        0.18fr
+      );
+    margin-inline: calc(var(--spacing-s) * -1);
+    padding: var(--spacing-l) var(--spacing-s);
+  }
+
+  .rates-ladder__copy,
+  .rates-ladder__price {
     display: grid;
     gap: var(--spacing-xs);
   }
 
-  .homepage-rate-bands a > div:first-child p {
+  .rates-ladder__copy p,
+  .rates-ladder dt,
+  .rates-ladder__price span {
     color: var(--color-gray-400);
     font-family: var(--font-mono);
     font-size: var(--text-step-000);
@@ -637,32 +635,24 @@ const pathname = Astro.url.pathname;
     text-transform: uppercase;
   }
 
-  .homepage-rate-bands span {
-    color: var(--homepage-soft);
-    font-family: var(--font-mono);
-    font-size: clamp(3rem, 7vw, 7rem);
-    font-weight: var(--font-weight-bold);
-    line-height: 0.9;
-  }
-
-  .homepage-rate-bands h3 {
-    font-size: var(--text-step-3);
+  .rates-ladder h3 {
+    font-size: var(--text-step-2);
     line-height: 1;
     margin: 0;
   }
 
-  .homepage-rate-bands a p {
-    margin: 0;
+  .rates-ladder__copy > span {
+    display: block;
+    max-inline-size: 36rem;
   }
 
-  .homepage-rate-bands dl {
-    align-self: end;
+  .rates-ladder dl {
     display: grid;
     gap: var(--spacing-2xs);
     margin: 0;
   }
 
-  .homepage-rate-bands dl div {
+  .rates-ladder dl div {
     align-items: baseline;
     border-block-start: 1px solid rgb(255 255 255 / 0.18);
     display: flex;
@@ -671,37 +661,23 @@ const pathname = Astro.url.pathname;
     padding-block-start: var(--spacing-2xs);
   }
 
-  .homepage-rate-bands dt {
-    color: var(--color-gray-400);
-    font-family: var(--font-mono);
-    font-size: var(--text-step-000);
-    font-weight: var(--font-weight-bold);
-    text-transform: uppercase;
-  }
-
-  .homepage-rate-bands dd {
+  .rates-ladder dd {
     font-weight: var(--font-weight-bold);
     margin: 0;
     text-align: end;
   }
 
-  .homepage-rates__note {
-    margin-block-start: var(--spacing-xl);
+  .rates-ladder__price {
+    align-self: start;
+    justify-items: end;
   }
 
-  .homepage-rates__note p {
-    color: var(--color-gray-1100);
-    font-size: var(--text-step-00);
-    margin: 0;
-    max-inline-size: 75ch;
-  }
-
-  .homepage-rates__note a {
-    color: currentColor;
+  .rates-ladder__price strong {
+    color: var(--homepage-soft);
+    font-family: var(--font-mono);
+    font-size: var(--text-step-1);
     font-weight: var(--font-weight-bold);
-    margin-inline-start: 0.12em;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 0.2em;
+    line-height: 1;
   }
 
   .homepage-contact {
@@ -811,9 +787,28 @@ const pathname = Astro.url.pathname;
     .homepage-creator ul,
     .homepage-range__intro,
     .homepage-system ol,
-    .homepage-rate-bands a,
+    .homepage-rates,
+    .rates-ladder__item,
     .homepage-contact {
       grid-template-columns: 1fr;
+    }
+
+    .rates-ladder__aside {
+      position: static;
+    }
+
+    .rates-ladder__price {
+      align-items: baseline;
+      border-block-start: 1px solid rgb(255 255 255 / 0.18);
+      display: flex;
+      justify-content: space-between;
+      justify-items: stretch;
+      order: 3;
+      padding-block-start: var(--spacing-s);
+    }
+
+    .rates-ladder dl {
+      order: 2;
     }
 
     .homepage-footer__terms {
@@ -823,7 +818,7 @@ const pathname = Astro.url.pathname;
     .homepage-hero__copy h1,
     .homepage-creator h2,
     .homepage-system h2,
-    .homepage-rates__intro h2,
+    .rates-ladder__aside h2,
     .homepage-contact h2 {
       max-inline-size: none;
     }

--- a/src/components/homepage/HomepageRates.astro
+++ b/src/components/homepage/HomepageRates.astro
@@ -1,52 +1,58 @@
 ---
 import { startingRates } from './data';
-import { homepageKicker } from './classes';
+import { homepageButtonLight } from './classes';
+
+const rates = startingRates.map((rate, index) => ({
+  ...rate,
+  outcome:
+    index === 0
+      ? 'Polished stills for launches, product pages, and social proof.'
+      : index === 1
+        ? 'A concise motion asset built for hooks, texture, and routine detail.'
+        : 'A more developed campaign-style story with polished pacing and lifestyle context.',
+  bestFor:
+    index === 0
+      ? 'Launch details'
+      : index === 1
+        ? 'Social conversion'
+        : 'Campaign storytelling',
+}));
 ---
 
-<section class="homepage-rates" id="Rates">
-  <div class="homepage-rates__intro">
-    <p class={homepageKicker}>Starting rates</p>
-    <h2>Simple entry points, scoped with campaign detail.</h2>
+<section class="homepage-rates" id="Rates" aria-labelledby="rates-title">
+  <div class="rates-ladder__aside">
+    <h2 id="rates-title">Simple entry points, scoped with campaign detail.</h2>
     <p>
-      Custom bundles, usage, raw footage, and campaign-specific needs are quoted
-      after we align on scope.
+      Start with the asset type that fits the campaign, then align on usage, raw
+      footage, and any campaign-specific needs.
     </p>
+    <a href="#Contact" class={homepageButtonLight}>Discuss scope</a>
   </div>
-  <div class="homepage-rate-bands">
+  <ol class="rates-ladder" aria-label="Starting rate progression">
     {
-      startingRates.map((rate) => (
-        <a
-          href="#Contact"
-          aria-label={`Contact Skin Schema about ${rate.title}`}
-        >
-          <div>
-            <p>{rate.type}</p>
-            <span>{rate.price}</span>
+      rates.map((rate) => (
+        <li>
+          <div class="rates-ladder__item">
+            <div class="rates-ladder__copy">
+              <p>{rate.bestFor}</p>
+              <h3>{rate.title}</h3>
+              <span>{rate.outcome}</span>
+            </div>
+            <dl>
+              {rate.specs.map(([label, value]) => (
+                <div>
+                  <dt>{label}</dt>
+                  <dd>{value}</dd>
+                </div>
+              ))}
+            </dl>
+            <div class="rates-ladder__price">
+              <span>Starts at</span>
+              <strong>{rate.price}</strong>
+            </div>
           </div>
-          <div>
-            <h3>{rate.title}</h3>
-            <p>{rate.text}</p>
-          </div>
-          <dl>
-            {rate.specs.map(([label, value]) => (
-              <div>
-                <dt>{label}</dt>
-                <dd>{value}</dd>
-              </div>
-            ))}
-          </dl>
-        </a>
+        </li>
       ))
     }
-  </div>
-  <div class="homepage-rates__note">
-    <p>
-      Organic brand-use rights are included for approved channels. Paid usage,
-      raw footage, rush delivery, perpetual usage, and extended distribution are
-      quoted separately based on campaign scope.<a
-        href="#CollaborationTerms"
-        aria-label="View collaboration terms">*</a
-      >
-    </p>
-  </div>
+  </ol>
 </section>


### PR DESCRIPTION
## Summary

The homepage rates section now uses the chosen investment-ladder layout instead of the old clickable rate bands. Packages read as informational rows with full specs, including Length, while `Discuss scope` is the only CTA.

## Verification

- `npm run build`
- Checked production preview at desktop and mobile.
- Confirmed the rates section has 1 link and 3 Length rows.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex-GPT--5-000000)
